### PR TITLE
Update dependencies for Ubuntu 20.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ You can install DATA GUI via the packages provided in the `dist` folder.
 We recommend to set up a virtual environment. To do so:
 
 ```
-sudo apt-get install virtualenv libxcb-xinerama0-dev
+sudo apt-get install virtualenv libcxb-xinerama0 libxcb-xinerama0-dev
 virtualenv -p /usr/bin/python3 .pyenv
 source .pyenv/bin/activate
 pip install -U setuptools pip click scipy sklearn

--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ You can install DATA GUI via the packages provided in the `dist` folder.
 We recommend to set up a virtual environment. To do so:
 
 ```
-sudo apt-get install virtualenv
-virtualenv -p /usr/bin/python3.5 .pyenv
+sudo apt-get install virtualenv libxcb-xinerama0-dev
+virtualenv -p /usr/bin/python3 .pyenv
 source .pyenv/bin/activate
-pip install -U setuptools pip
+pip install -U setuptools pip click scipy sklearn
 pip install dist/datagui-x.x.tar.gz
 ```
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ You can install DATA GUI via the packages provided in the `dist` folder.
 We recommend to set up a virtual environment. To do so:
 
 ```
-sudo apt-get install virtualenv libcxb-xinerama0 libxcb-xinerama0-dev
+sudo apt-get install virtualenv libcxb-xinerama0 libxcb-xinerama0-dev libxcb-image0 libxcb-keysyms, libxcb-render-util0 libxcb-xkb1 libxkbcommon-x11-0 libxcb-icccm4
 virtualenv -p /usr/bin/python3 .pyenv
 source .pyenv/bin/activate
 pip install -U setuptools pip click scipy sklearn

--- a/datagui/package/ui/SummaryTab.py
+++ b/datagui/package/ui/SummaryTab.py
@@ -18,6 +18,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 """
 
+import math
 from PyQt5.QtCore import QSize
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QWidget, QSizePolicy, QGroupBox, QGridLayout, QHBoxLayout, QButtonGroup, QTextEdit, QLabel
@@ -67,7 +68,7 @@ class SummaryTab(QWidget):
         flags_group_box = QGroupBox("Rating")
         #icon_size = QSize(20, 20)
         font_size = QFontMetrics(self.user_comment.currentFont()).size(0,"A").height()
-        font_size *= 1.1
+        font_size = math.ceil(font_size * 1.1)
         icon_size = QSize(font_size, font_size)
         
         flag_0 = createIconButton(icon_size, LeakFlags.NOLEAK)


### PR DESCRIPTION
When installing the GUI on a fresh Ubuntu 20.04.03, I had to install a few more dependencies. Also Python 3.5 is no longer in the official repositories, however it seems like the GUI and DATA itself also work with python 3.8.

The last thing could however require further testing.